### PR TITLE
handle single input neuron returned by layer with single output

### DIFF
--- a/micrograd/nn.py
+++ b/micrograd/nn.py
@@ -18,6 +18,7 @@ class Neuron(Module):
         self.nonlin = nonlin
 
     def __call__(self, x):
+        x = [x] if isinstance(x, Value) else x
         act = sum((wi*xi for wi,xi in zip(self.w, x)), self.b)
         return act.relu() if self.nonlin else act
 


### PR DESCRIPTION
The `Layer` class special cases single output neurons:
```python3
return out[0] if len(out) == 1 else out
```

This is nice for loss functions but currently breaks for intermediate layers with a single neuron.

```python3
from micrograd.nn import MLP
from micrograd.engine import Value

# works
model = MLP(2, [16, 16, 1])
x = [Value(1.0), Value(-2.0)]
print(model(x))

# fails: intermediate layer with 1 neuron
model = MLP(2, [16, 1, 1])
x = [Value(1.0), Value(-2.0)]
print(model(x))
```

This PR fixes this by correctly handling a single input `Value`.

Note that I currently only check for `Value` instances explicitly, which is good enough for intermediate layers.

To handle single network input neurons, we should also check for float and int scalars. I kept it as minimal as possible for now, but I can add that if you want. (Technically, it would probably be best to check if the input is iterable or not, but doing that right nowadays requires a [try](https://stackoverflow.com/questions/1952464/in-python-how-do-i-determine-if-an-object-is-iterable) statement.)