### PR TITLE
Bugfix : Value class initializer

### DIFF
--- a/micrograd/engine.py
+++ b/micrograd/engine.py
@@ -3,7 +3,7 @@ class Value:
     """ stores a single scalar value and its gradient """
 
     def __init__(self, data, _children=(), _op=''):
-        self.data = data
+        self.data = data.data if isinstance(data, Value) else data 
         self.grad = 0
         # internal variables used for autograd graph construction
         self._backward = lambda: None


### PR DESCRIPTION
The bug only pops up if a crazy person like me accidentally or intentionally re-initiates a value.

before the fix:
a = Value(2.0)
b = Value(a)
print(b)
output: Value(data=Value(data=2.0, grad=0), grad=0)

after the fix: 
a = Value(2.0)
b = Value(a)
print(b)
output: Value(data=2.0, grad=0)

it's very minor and can be ignored but would mean a lot for my very first open-source contribution