### PR TITLE
Simplify topo sorted traversal to depth first traversal

### DIFF
--- a/micrograd/engine.py
+++ b/micrograd/engine.py
@@ -52,22 +52,9 @@ class Value:
         return out
 
     def backward(self):
-
-        # topological order all of the children in the graph
-        topo = []
-        visited = set()
-        def build_topo(v):
-            if v not in visited:
-                visited.add(v)
-                for child in v._prev:
-                    build_topo(child)
-                topo.append(v)
-        build_topo(self)
-
-        # go one variable at a time and apply the chain rule to get its gradient
         self.grad = 1
-        for v in reversed(topo):
-            v._backward()
+        self._backward()
+        [n._backward() for n in self._prev]
 
     def __neg__(self): # -self
         return self * -1


### PR DESCRIPTION
Each node points to 0 or 1 other node, never to more. There's only one unique path by which each node can be reached by going backwards from the output node. This means that in the `backward()` method `v` is never already in `visited`. The algorithm thus simplifies to a depth-first traversal.

Side-note: if a node could be reached by more than 1 path from the output node, the node would have a different gradient for each of the paths. So, while you could reuse nodes for the forward calculation and get correct results, there's no facility to store several gradients per node. Thus it's unnecessary to account for this possibility here.