### PR TITLE
simplify back propagation (remove unnecessary sequence traversal)

### DIFF
--- a/micrograd/engine.py
+++ b/micrograd/engine.py
@@ -53,21 +53,15 @@ class Value:
 
     def backward(self):
 
-        # topological order all of the children in the graph
-        topo = []
+        self.grad = 1
         visited = set()
-        def build_topo(v):
+        def chain_gradients(v):
             if v not in visited:
                 visited.add(v)
+                v._backward()
                 for child in v._prev:
-                    build_topo(child)
-                topo.append(v)
-        build_topo(self)
-
-        # go one variable at a time and apply the chain rule to get its gradient
-        self.grad = 1
-        for v in reversed(topo):
-            v._backward()
+                    chain_gradients(child)
+        chain_gradients(self)
 
     def __neg__(self): # -self
         return self * -1


### PR DESCRIPTION
The original recursive back propagation algorithm performs breadth-first visiting of Values in the graph, simply to add them to a linear sequence. The sequence is then reversed and iterated over to invoke the _backward() function in each Value.

It is possible to invoke the _backward() function in a single pass _during_ the breadth-first visiting of Values, without creating an interim linear sequence. This PR simplifies the algorithm accordingly.