### PR TITLE
Update __pow__() and __rpow__() method

### DIFF
--- a/micrograd/engine.py
+++ b/micrograd/engine.py
@@ -99,5 +99,8 @@ class Value:
     def __rtruediv__(self, other): # other / self
         return other * self**-1
 
+    def __rpow__(self, other):
+        return self ** other
+
     def __repr__(self):
         return f"Value(data={self.data}, grad={self.grad})"

--- a/micrograd/engine.py
+++ b/micrograd/engine.py
@@ -1,3 +1,4 @@
+import math
 
 class Value:
     """ stores a single scalar value and its gradient """
@@ -33,14 +34,22 @@ class Value:
         return out
 
     def __pow__(self, other):
-        assert isinstance(other, (int, float)), "only supporting int/float powers for now"
-        out = Value(self.data**other, (self,), f'**{other}')
-
+        other_grad = True
+        
+        if not isinstance(other, Value):
+            other_grad = False
+            other = Value(other)
+        
+        result = Value(self.data ** other.data , (self,other) , '**')
+        
         def _backward():
-            self.grad += (other * self.data**(other-1)) * out.grad
-        out._backward = _backward
-
-        return out
+            self.grad += (other.data) * ((self.data) ** (other.data - 1)) * (result.grad) 
+            if other_grad : 
+                other.grad += round((self.data ** other.data) * math.log(self.data),4)
+            
+        result._backward = _backward
+        
+        return result
 
     def relu(self):
         out = Value(0 if self.data < 0 else self.data, (self,), 'ReLU')
@@ -92,3 +101,15 @@ class Value:
 
     def __repr__(self):
         return f"Value(data={self.data}, grad={self.grad})"
+
+a = Value(2.0)
+b = Value(3.0)
+
+c = a ** b
+
+print(c.data)
+c.backward()
+
+print(c.grad)
+print(a.grad)
+print(b.grad)

--- a/micrograd/engine.py
+++ b/micrograd/engine.py
@@ -100,7 +100,21 @@ class Value:
         return other * self**-1
 
     def __rpow__(self, other):
-        return self ** other
+        other_grad = True
+        if not isinstance(other , Value):
+            other_grad = False
+            other = Value(other)
+            
+        result = Value(other.data ** self.data , (self,other) , '**')
+        
+        def _backward():
+            self.grad = round((other.data ** self.data) * math.log(other.data) , 4)
+            if other_grad:
+                other.grad += (other.data) * ((self.data) ** (other.data - 1)) * (result.grad)
+            
+        result._backward = _backward
+        
+        return result
 
     def __repr__(self):
         return f"Value(data={self.data}, grad={self.grad})"

--- a/micrograd/engine.py
+++ b/micrograd/engine.py
@@ -101,15 +101,3 @@ class Value:
 
     def __repr__(self):
         return f"Value(data={self.data}, grad={self.grad})"
-
-a = Value(2.0)
-b = Value(3.0)
-
-c = a ** b
-
-print(c.data)
-c.backward()
-
-print(c.grad)
-print(a.grad)
-print(b.grad)


### PR DESCRIPTION
### What
I have added the utility of `__pow__(self , other)`  `__rpow__(self , other)` methods where it can now use the **base** as well as the **exponent** as `Value` objects. It also allows for flow of gradient through the `other` attribute if and only if the `other` is of **type** `Value`. If `other `is **integer** or **float**, we _ignore_ the flow of gradient through other.

***

### Why
This allows the `__pow__(self,other)` to be similar to the other basic methods like `__add__(self,other)` , `__mul__(self,other)__` , etc. which allows for both the inputs to be `Value` objects or one of them to be `Value` and the other to be any numeric type.

***

### How
The implementation was very basic and was implemented using the basic `__pow__ ` and `__rpow__` magic methods.

***

### Testing
I tested with the following three scenarios and I have pasted the results as screenshots.

**First scenario**

```python
a = Value(2.0)
b = Value(3.0)
c = a ** b
c.backward()

print(f'In a ** b :')
print(f'a : {a}')
print(f'b : {b}')
print(f'c : {c}')
```

Output
```console
In a ** b :
a : Value(data=2.0, grad=12.0)
b : Value(data=3.0, grad=5.5452)
c : Value(data=8.0, grad=1)
```
***

**Second scenario**

```python
a = 2.0
b = Value(3.0)
c = a ** b
c.backward()

print(f'In a ** b :')
print(f'a : {a}')
print(f'b : {b}')
print(f'c : {c}')
```

Output
```console
In a ** b :
a : 2.0
b : Value(data=3.0, grad=5.5452)
c : Value(data=8.0, grad=1)
```

***

**Third scenario**

```python
a = Value(2.0)
b = 3.0
c = a ** b
c.backward()

print(f'In a ** b :')
print(f'a : {a}')
print(f'b : {b}')
print(f'c : {c}')
```

Output
```console
In a ** b :
a : Value(data=2.0, grad=12.0)
b : 3.0
c : Value(data=8.0, grad=1)
```

