### PR TITLE
Ensure backward() idempotence

### DIFF
--- a/micrograd/engine.py
+++ b/micrograd/engine.py
@@ -64,6 +64,9 @@ class Value:
                 topo.append(v)
         build_topo(self)
 
+        # reset gradients to ensure they don't get repeatedly accumulated
+        # for v in reversed(topo):
+        #     v.grad = 0
         # go one variable at a time and apply the chain rule to get its gradient
         self.grad = 1
         for v in reversed(topo):


### PR DESCRIPTION
As per [issue 53](https://github.com/karpathy/micrograd/issues/53) -- just makes `backward()` do a quick first pass over the tree to reset grads, ensuring that `backward()` is idempotent so that users don't trip over accidentally calling it twice without redefining the values.