### PR TITLE
Create .gitattributes file in order to correct file type statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-documentation


### PR DESCRIPTION
Currently on github file statistics show this project has 90% jupyter notebook. This PR will add .gitattributes file which will correct those statistics as 100% python.
```plaintext
Jupyter Notebook 90.3%
Python 9.7%
```

```plaintext
Python 100%
```