### PR TITLE
Enable micrograd to use tanh activation function dynamically

### DIFF
--- a/micrograd/engine.py
+++ b/micrograd/engine.py
@@ -1,14 +1,16 @@
+import math
 
 class Value:
     """ stores a single scalar value and its gradient """
 
-    def __init__(self, data, _children=(), _op=''):
+    def __init__(self, data, _children=(), _op='', label=''):
         self.data = data
         self.grad = 0
         # internal variables used for autograd graph construction
         self._backward = lambda: None
         self._prev = set(_children)
         self._op = _op # the op that produced this node, for graphviz / debugging / etc
+        self.label = label # label of this node
 
     def __add__(self, other):
         other = other if isinstance(other, Value) else Value(other)
@@ -50,6 +52,18 @@ class Value:
         out._backward = _backward
 
         return out
+    
+    def tanh(self):
+        x = self.data
+        t = (math.exp(2*x) - 1)/(math.exp(2*x) + 1)
+        out = Value(t, (self, ), 'tanh')
+
+        def _backward():
+            self.grad += (1 - t**2) * out.grad
+        out._backward = _backward
+
+        return out
+
 
     def backward(self):
 

--- a/micrograd/nn.py
+++ b/micrograd/nn.py
@@ -12,19 +12,30 @@ class Module:
 
 class Neuron(Module):
 
-    def __init__(self, nin, nonlin=True):
+    def __init__(self, nin, nonlin=True, use_tanh=False):
         self.w = [Value(random.uniform(-1,1)) for _ in range(nin)]
         self.b = Value(0)
         self.nonlin = nonlin
+        self.use_tanh = use_tanh
 
     def __call__(self, x):
         act = sum((wi*xi for wi,xi in zip(self.w, x)), self.b)
+        
+        if self.use_tanh:
+            # If specified to use a Tanh activation function
+            return act.tanh()
+        
+        # By default uses a relu activation function.
+        # Maybe we can extend this to dynamically to pick activation
+        # functions at the caller end.
         return act.relu() if self.nonlin else act
 
     def parameters(self):
         return self.w + [self.b]
 
     def __repr__(self):
+        if self.use_tanh:
+            return f"{'Tanh' if self.nonlin else 'Linear'}Neuron({len(self.w)})"
         return f"{'ReLU' if self.nonlin else 'Linear'}Neuron({len(self.w)})"
 
 class Layer(Module):
@@ -44,9 +55,9 @@ class Layer(Module):
 
 class MLP(Module):
 
-    def __init__(self, nin, nouts):
+    def __init__(self, nin, nouts, use_tanh=False):
         sz = [nin] + nouts
-        self.layers = [Layer(sz[i], sz[i+1], nonlin=i!=len(nouts)-1) for i in range(len(nouts))]
+        self.layers = [Layer(sz[i], sz[i+1], nonlin=i!=len(nouts)-1, use_tanh=use_tanh) for i in range(len(nouts))]
 
     def __call__(self, x):
         for layer in self.layers:
@@ -57,4 +68,4 @@ class MLP(Module):
         return [p for layer in self.layers for p in layer.parameters()]
 
     def __repr__(self):
-        return f"MLP of [{', '.join(str(layer) for layer in self.layers)}]"
+        return f"MLPO of [{', '.join(str(layer) for layer in self.layers)}]"

--- a/micrograd/nn.py
+++ b/micrograd/nn.py
@@ -23,7 +23,7 @@ class Neuron(Module):
         
         if self.use_tanh:
             # If specified to use a Tanh activation function
-            return act.tanh()
+            return act.tanh() if self.nonlin else act
         
         # By default uses a relu activation function.
         # Maybe we can extend this dynamically to pick activation

--- a/micrograd/nn.py
+++ b/micrograd/nn.py
@@ -26,7 +26,7 @@ class Neuron(Module):
             return act.tanh()
         
         # By default uses a relu activation function.
-        # Maybe we can extend this to dynamically to pick activation
+        # Maybe we can extend this dynamically to pick activation
         # functions at the caller end.
         return act.relu() if self.nonlin else act
 

--- a/micrograd/nn.py
+++ b/micrograd/nn.py
@@ -68,4 +68,4 @@ class MLP(Module):
         return [p for layer in self.layers for p in layer.parameters()]
 
     def __repr__(self):
-        return f"MLPO of [{', '.join(str(layer) for layer in self.layers)}]"
+        return f"MLP of [{', '.join(str(layer) for layer in self.layers)}]"


### PR DESCRIPTION
I was working with **micrograd** and the loss values were not converging when I was training it on one of my datasets. Looks like the tutorial encourage the use of `tanh()` as an **activation** function but the repo lacked implementation.

The PR includes the following changes:

  - Implementation of `tanh()` activation function and allowing the end users to opt for whether they want to use `tanh()` or stay with `relu()` as their choice of activation function at the time of initializing the Multi Layer Perceptron.
  - Enable support of `Label` for the Value. This helps in debugging when used with Digraph :)

Please review when you get sometime @karpathy. 
Big fan! :)