### PR TITLE
Changed the backward method implementation from recursive to stack

### DIFF
--- a/micrograd/engine.py
+++ b/micrograd/engine.py
@@ -52,22 +52,21 @@ class Value:
         return out
 
     def backward(self):
-
-        # topological order all of the children in the graph
         topo = []
         visited = set()
-        def build_topo(v):
+        stack = [self]
+        
+        while stack:
+            v = stack.pop()
             if v not in visited:
                 visited.add(v)
-                for child in v._prev:
-                    build_topo(child)
+                stack.extend(v._prev)
                 topo.append(v)
-        build_topo(self)
+                
+        self.grad = 1.0
+        for node in topo:
+            node._backward()
 
-        # go one variable at a time and apply the chain rule to get its gradient
-        self.grad = 1
-        for v in reversed(topo):
-            v._backward()
 
     def __neg__(self): # -self
         return self * -1


### PR DESCRIPTION
I run into a proble of `RecursionError` when the depth of the graph is longer than 1000. That may happen when there is a very long mathematical expression based on atomic operations (+, -, etc.). So the new implementation is based on the DPS algorithm using a stack. This removes the recursion limit (default to 1000) and can create a topological graph for an infinite depth.